### PR TITLE
LPS-76969 Print Warn message in log instead of full StackTrace

### DIFF
--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/Netlogon.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/Netlogon.java
@@ -90,17 +90,19 @@ public class Netlogon {
 				return new NtlmUserAccount(name.toString());
 			}
 
-			SmbException smbe = new SmbException(
-				netrLogonSamLogon.getStatus(), false);
+			if (_log.isWarnEnabled()) {
+				SmbException smbe = new SmbException(
+					netrLogonSamLogon.getStatus(), false);
 
-			StringBundler sb = new StringBundler(4);
+				StringBundler sb = new StringBundler(4);
 
-			sb.append("Unable to authenticate user ");
-			sb.append(userName);
-			sb.append(": ");
-			sb.append(smbe.getMessage());
+				sb.append("Unable to authenticate user ");
+				sb.append(userName);
+				sb.append(": ");
+				sb.append(smbe.getMessage());
 
-			_log.warn(sb.toString());
+				_log.warn(sb.toString());
+			}
 
 			return null;
 		}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/Netlogon.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/Netlogon.java
@@ -16,6 +16,7 @@ package com.liferay.portal.security.sso.ntlm.internal;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.security.sso.ntlm.internal.msrpc.NetlogonAuthenticator;
 import com.liferay.portal.security.sso.ntlm.internal.msrpc.NetlogonIdentityInfo;
 import com.liferay.portal.security.sso.ntlm.internal.msrpc.NetlogonNetworkInfo;
@@ -92,8 +93,16 @@ public class Netlogon {
 			SmbException smbe = new SmbException(
 				netrLogonSamLogon.getStatus(), false);
 
-			throw new NtlmLogonException(
-				"Unable to authenticate user: " + smbe.getMessage());
+			StringBundler sb = new StringBundler(4);
+
+			sb.append("Unable to authenticate user ");
+			sb.append(userName);
+			sb.append(": ");
+			sb.append(smbe.getMessage());
+
+			_log.warn(sb.toString());
+
+			return null;
 		}
 		catch (NoSuchAlgorithmException nsae) {
 			throw new NtlmLogonException(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-28495

In order to contribute useful information in logs, I've added user name to warn trace when unable to authenticate user by NTLM.

Thanks!   