### PR TITLE
[TECHNICAL-SUPPORT] LPS-90188 - counter proposal

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -490,16 +490,6 @@ public class LDAPAuth implements Authenticator {
 			return Authenticator.SKIP_LIFERAY_CHECK;
 		}
 
-		boolean anyFailure = false;
-		boolean anyDne = false;
-
-		if (preferredLDAPServerResult == FAILURE) {
-			anyFailure = true;
-		}
-		else if (preferredLDAPServerResult == DNE) {
-			anyDne = true;
-		}
-
 		List<LDAPServerConfiguration> ldapServerConfigurations =
 			_ldapServerConfigurationProvider.getConfigurations(companyId);
 
@@ -527,24 +517,10 @@ public class LDAPAuth implements Authenticator {
 
 				return Authenticator.SKIP_LIFERAY_CHECK;
 			}
-
-			if (result == FAILURE) {
-				anyFailure = true;
-			}
-			else if (result == DNE) {
-				anyDne = true;
-			}
 		}
 
-		int authResult = authenticateRequired(
+		return authenticateRequired(
 			companyId, userId, emailAddress, screenName, true, FAILURE);
-
-		if ((authResult != SUCCESS) || (anyDne && !anyFailure)) {
-			return authResult;
-		}
-
-		return authenticateImportEnable(
-			companyId, userId, emailAddress, screenName, true, FAILURE, false);
 	}
 
 	protected int authenticateAgainstPreferredLDAPServer(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -522,7 +522,7 @@ public class LDAPAuth implements Authenticator {
 		int authResult = authenticateRequired(
 			companyId, userId, emailAddress, screenName, true, FAILURE);
 
-		if (authResult != SUCCESS) {
+		if ((authResult != SUCCESS) || (preferredLDAPServerId == -1)) {
 			return authResult;
 		}
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -42,6 +42,7 @@ import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
 import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
 import com.liferay.portal.security.ldap.constants.LDAPConstants;
 import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
+import com.liferay.portal.security.ldap.exportimport.configuration.LDAPExportConfiguration;
 import com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration;
 import com.liferay.portal.security.ldap.util.LDAPUtil;
 
@@ -489,6 +490,16 @@ public class LDAPAuth implements Authenticator {
 			return Authenticator.SKIP_LIFERAY_CHECK;
 		}
 
+		boolean anyFailure = false;
+		boolean anyDne = false;
+
+		if (preferredLDAPServerResult == FAILURE) {
+			anyFailure = true;
+		}
+		else if (preferredLDAPServerResult == DNE) {
+			anyDne = true;
+		}
+
 		List<LDAPServerConfiguration> ldapServerConfigurations =
 			_ldapServerConfigurationProvider.getConfigurations(companyId);
 
@@ -516,10 +527,24 @@ public class LDAPAuth implements Authenticator {
 
 				return Authenticator.SKIP_LIFERAY_CHECK;
 			}
+
+			if (result == FAILURE) {
+				anyFailure = true;
+			}
+			else if (result == DNE) {
+				anyDne = true;
+			}
 		}
 
-		return authenticateRequired(
+		int authResult = authenticateRequired(
 			companyId, userId, emailAddress, screenName, true, FAILURE);
+
+		if ((authResult != SUCCESS) || (anyDne && !anyFailure)) {
+			return authResult;
+		}
+
+		return authenticateImportEnable(
+			companyId, userId, emailAddress, screenName, true, FAILURE, false);
 	}
 
 	protected int authenticateAgainstPreferredLDAPServer(
@@ -548,6 +573,36 @@ public class LDAPAuth implements Authenticator {
 			password);
 
 		return result;
+	}
+
+	protected int authenticateImportEnable(
+			long companyId, long userId, String emailAddress, String screenName,
+			boolean allowOmniadmin, int failureCode, boolean exportEnabled)
+		throws Exception {
+
+		// Make exceptions for omniadmins so that if they break the LDAP
+		// configuration, they can still login to fix the problem
+
+		if (allowOmniadmin &&
+			(authenticateOmniadmin(
+				companyId, emailAddress, screenName, userId) == SUCCESS)) {
+
+			return SUCCESS;
+		}
+
+		LDAPImportConfiguration ldapImportConfiguration =
+			_ldapImportConfigurationProvider.getConfiguration(companyId);
+
+		LDAPExportConfiguration ldapExportConfiguration =
+			_ldapExportConfigurationProvider.getConfiguration(companyId);
+
+		if (ldapImportConfiguration.importEnabled() &&
+			(ldapExportConfiguration.exportEnabled() == exportEnabled)) {
+
+			return failureCode;
+		}
+
+		return SUCCESS;
 	}
 
 	protected int authenticateOmniadmin(
@@ -725,6 +780,17 @@ public class LDAPAuth implements Authenticator {
 	}
 
 	@Reference(
+		target = "(factoryPid=com.liferay.portal.security.ldap.exportimport.configuration.LDAPExportConfiguration)",
+		unbind = "-"
+	)
+	protected void setLDAPExportConfigurationProvider(
+		ConfigurationProvider<LDAPExportConfiguration>
+			ldapExportConfigurationProvider) {
+
+		_ldapExportConfigurationProvider = ldapExportConfigurationProvider;
+	}
+
+	@Reference(
 		target = "(factoryPid=com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration)",
 		unbind = "-"
 	)
@@ -790,6 +856,8 @@ public class LDAPAuth implements Authenticator {
 			LDAPAuth.class + "._failedLDAPAuthResultCache", HashMap::new);
 	private ConfigurationProvider<LDAPAuthConfiguration>
 		_ldapAuthConfigurationProvider;
+	private ConfigurationProvider<LDAPExportConfiguration>
+		_ldapExportConfigurationProvider;
 	private ConfigurationProvider<LDAPImportConfiguration>
 		_ldapImportConfigurationProvider;
 	private ConfigurationProvider<LDAPServerConfiguration>

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -519,8 +519,15 @@ public class LDAPAuth implements Authenticator {
 			}
 		}
 
-		return authenticateRequired(
+		int authResult = authenticateRequired(
 			companyId, userId, emailAddress, screenName, true, FAILURE);
+
+		if (authResult != SUCCESS) {
+			return authResult;
+		}
+
+		return authenticateImportEnable(
+			companyId, userId, emailAddress, screenName, true, FAILURE, false);
 	}
 
 	protected int authenticateAgainstPreferredLDAPServer(


### PR DESCRIPTION
Hi Jose. Thanks for your pull request. Did you consider a solution as simpler like this? I think it covers all the scenarios, but maybe I am missing some context.

Based on @ChrisKian 's [comment](https://issues.liferay.com/browse/PTR-591?focusedCommentId=1691942&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1691942), which I agree with, I believe this boils down to:

- If no LDAP server could authenticate, then return SUCCESS only if LDAP auth is optional or portal user export is enabled

I don't think we need to switch between the old and new behavior depending on the state of the connected LDAP directories (see [comment](https://github.com/stian-sigvartsen/liferay-portal/pull/142/commits/948297d7a0390e8e8c9c93bc39cf01e379cab8cf#r256934241))?

/cc @topolik @martamedio